### PR TITLE
Add total count cache options

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,6 @@ $ php bin/console assets:install --symlink
 {{ hello_bootstrap_table_js() }}
 ```
 
-You can also use other CSS frameworks. See the bootstrap-table documentation for more information.
-
 ---
 
 ## Your First Table
@@ -874,6 +872,7 @@ All options that should not be provided directly as data-attributes of the table
 | bulkActions                | array  | [ ]                             |
 | bulkButtonName             | string | "Okay"                          |
 | bulkButtonClassNames       | string | "btn btn-primary"               |
+| enableTotalCountCache      | bool   | false                           |
 
 
 #### Examples

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": ">=7.2.5",
         "ext-json": "*",
         "doctrine/common": "^2.6|^3.0",
-        "doctrine/orm": "^2.6.3",
+        "doctrine/orm": "^2.10",
         "sensio/framework-extra-bundle": "^5.1|^6.1",
         "symfony/property-access": "^4.4|^5.0|^6.0",
         "symfony/security-bundle": "^4.4|^5.0|^6.0",

--- a/src/HelloBootstrapTable.php
+++ b/src/HelloBootstrapTable.php
@@ -141,7 +141,7 @@ abstract class HelloBootstrapTable
      */
     public function getResponse()
     {
-        return new JsonResponse($this->tableResponse->getData());
+        return new JsonResponse($this->tableResponse->getData($this->tableOptions["enableTotalCountCache"]));
     }
 
     /**
@@ -406,7 +406,8 @@ abstract class HelloBootstrapTable
             'bulkActionSelectClassNames' => 'form-control',
             'bulkActions' => array(),
             'bulkButtonName' => 'Okay',
-            'bulkButtonClassNames' => 'btn btn-primary'
+            'bulkButtonClassNames' => 'btn btn-primary',
+            'enableTotalCountCache' => false
         ));
 
         $resolver->setAllowedTypes("tableClassNames", ["string"]);
@@ -417,5 +418,6 @@ abstract class HelloBootstrapTable
         $resolver->setAllowedTypes("bulkActions", ["array"]);
         $resolver->setAllowedTypes("bulkButtonName", ["string"]);
         $resolver->setAllowedTypes("bulkButtonClassNames", ["string"]);
+        $resolver->setAllowedTypes("enableTotalCountCache", ["bool"]);
     }
 }

--- a/src/Response/TableResponse.php
+++ b/src/Response/TableResponse.php
@@ -110,11 +110,12 @@ class TableResponse
     /**
      * Gets all fetches data from database with total count.
      *
+     * @param boolean $enableTotalCountCache
      * @return array
      */
-    public function getData()
+    public function getData($enableTotalCountCache)
     {
-        $entities = $this->doctrineQueryBuilder->fetchData($this->requestData);
+        $entities = $this->doctrineQueryBuilder->fetchData($this->requestData, $enableTotalCountCache);
 
         return array(
             "rows" => $this->dataBuilder->buildDataAsArray($entities),


### PR DESCRIPTION
When large and complex tables are built over multiple entities and have several 100k records, the initial count of the total amount of records takes a very long time. This is most likely due to the LEFT JOINS.

With the option enableTotalCountCache the result of the count can now be cached.