### PR TITLE
Add parameter types and return types

### DIFF
--- a/src/Columns/AbstractColumn.php
+++ b/src/Columns/AbstractColumn.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace HelloSebastian\HelloBootstrapTableBundle\Columns;
-
 
 use HelloSebastian\HelloBootstrapTableBundle\Filters\AbstractFilter;
 use HelloSebastian\HelloBootstrapTableBundle\Filters\TextFilter;
@@ -55,7 +53,7 @@ abstract class AbstractColumn
         $this->setOptions($options);
     }
 
-    public function setOptions($options)
+    public function setOptions($options): void
     {
         //configure resolvers ...
         $outputOptionResolver = new OptionsResolver();
@@ -104,7 +102,7 @@ abstract class AbstractColumn
      *
      * @param RouterInterface $router
      */
-    public function setRouter(RouterInterface $router)
+    public function setRouter(RouterInterface $router): void
     {
         $this->router = $router;
     }
@@ -114,14 +112,14 @@ abstract class AbstractColumn
      *
      * @param ColumnBuilder $columnBuilder
      */
-    public function setColumnBuilder(ColumnBuilder $columnBuilder)
+    public function setColumnBuilder(ColumnBuilder $columnBuilder): void
     {
         $this->columnBuilder = $columnBuilder;
     }
 
     /**
      * @param $entity
-     * @return array
+     * @return array|string
      */
     public abstract function buildData($entity);
 
@@ -136,7 +134,7 @@ abstract class AbstractColumn
      * @param string $key
      * @param mixed $value
      */
-    public function replaceOption($key, $value)
+    public function replaceOption(string $key, $value)
     {
         $options = array_merge($this->outputOptions, $this->internalOptions);
         $options[$key] = $value;
@@ -144,7 +142,7 @@ abstract class AbstractColumn
         $this->setOptions($options);
     }
 
-    public function getOutputOptions($filterNulls = true)
+    public function getOutputOptions(bool $filterNulls = true): array
     {
         if ($filterNulls) {
             $outputOptions = $this->outputOptions;
@@ -157,7 +155,7 @@ abstract class AbstractColumn
         return $this->outputOptions;
     }
 
-    public function getPropertyPath()
+    public function getPropertyPath(): string
     {
         if ($this->isAssociation()) {
             $parts = explode(".", $this->dql);
@@ -168,57 +166,57 @@ abstract class AbstractColumn
         return $this->dql;
     }
 
-    public function getField()
+    public function getField(): string
     {
         return $this->outputOptions['field'];
     }
 
-    public function getFilter()
+    public function getFilter(): ?AbstractFilter
     {
         return $this->filter;
     }
 
-    public function getDataCallback()
+    public function getDataCallback(): ?\Closure
     {
         return $this->internalOptions['data'];
     }
 
-    public function getSortCallback()
+    public function getSortCallback(): ?\Closure
     {
         return $this->internalOptions['sort'];
     }
 
-    public function getSearchCallback()
+    public function getSearchCallback(): ?\Closure
     {
         return $this->internalOptions['search'];
     }
 
-    public function getAddIfCallback()
+    public function getAddIfCallback(): ?\Closure
     {
         return $this->internalOptions['addIf'];
     }
 
-    public function getEmptyData()
+    public function getEmptyData(): string
     {
         return $this->internalOptions['emptyData'];
     }
 
-    public function isAssociation()
+    public function isAssociation(): bool
     {
         return (false !== strpos($this->dql, "."));
     }
 
-    public function isSearchable()
+    public function isSearchable(): bool
     {
         return $this->outputOptions['searchable'];
     }
 
-    public function getColumnBuilder()
+    public function getColumnBuilder(): ColumnBuilder
     {
         return $this->columnBuilder;
     }
 
-    protected function configureInternalOptions(OptionsResolver $resolver)
+    protected function configureInternalOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(array(
             'emptyData' => '',
@@ -226,7 +224,7 @@ abstract class AbstractColumn
             'sort' => null,
             'search' => null,
             'filter' => array(TextFilter::class, array()),
-            'addIf' => function() {
+            'addIf' => function () {
                 return true;
             }
         ));
@@ -239,7 +237,7 @@ abstract class AbstractColumn
         $resolver->setAllowedTypes('addIf', ['Closure']);
     }
 
-    protected function configureOutputOptions(OptionsResolver $resolver)
+    protected function configureOutputOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(array(
             'title' => null,
@@ -289,5 +287,4 @@ abstract class AbstractColumn
         $resolver->setAllowedTypes('footerFormatter', ['string', 'null']);
         $resolver->setAllowedTypes('filterControl', ['string']);
     }
-
 }

--- a/src/Columns/ActionColumn.php
+++ b/src/Columns/ActionColumn.php
@@ -1,15 +1,13 @@
 <?php
 
-
 namespace HelloSebastian\HelloBootstrapTableBundle\Columns;
-
 
 use HelloSebastian\HelloBootstrapTableBundle\Data\ActionButton;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ActionColumn extends AbstractColumn
 {
-    protected function configureOutputOptions(OptionsResolver $resolver)
+    protected function configureOutputOptions(OptionsResolver $resolver): void
     {
         parent::configureOutputOptions($resolver);
 
@@ -55,7 +53,7 @@ class ActionColumn extends AbstractColumn
     /**
      * Creates for each array item a ActionButton object and replace it in buttons array.
      */
-    private function buildButtons()
+    private function buildButtons(): void
     {
         foreach ($this->outputOptions['buttons'] as $key => $button) {
             if (is_array($button)) {
@@ -63,5 +61,4 @@ class ActionColumn extends AbstractColumn
             }
         }
     }
-
 }

--- a/src/Columns/BooleanColumn.php
+++ b/src/Columns/BooleanColumn.php
@@ -7,7 +7,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class BooleanColumn extends AbstractColumn
 {
-    protected function configureOutputOptions(OptionsResolver $resolver)
+    protected function configureOutputOptions(OptionsResolver $resolver): void
     {
         parent::configureOutputOptions($resolver);
 
@@ -23,7 +23,7 @@ class BooleanColumn extends AbstractColumn
         $resolver->setAllowedTypes('falseLabel', 'string');
     }
 
-    protected function configureInternalOptions(OptionsResolver $resolver)
+    protected function configureInternalOptions(OptionsResolver $resolver): void
     {
         parent::configureInternalOptions($resolver);
 

--- a/src/Columns/ColumnBuilder.php
+++ b/src/Columns/ColumnBuilder.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace HelloSebastian\HelloBootstrapTableBundle\Columns;
-
 
 use Symfony\Component\Routing\RouterInterface;
 
@@ -31,7 +29,7 @@ class ColumnBuilder
      * @param RouterInterface $router
      * @param array $defaultButtonOptions
      */
-    public function __construct(RouterInterface $router, $defaultButtonOptions)
+    public function __construct(RouterInterface $router, array $defaultButtonOptions)
     {
         $this->router = $router;
         $this->defaultButtonOptions = $defaultButtonOptions;
@@ -43,7 +41,7 @@ class ColumnBuilder
      * @param string $field
      * @return AbstractColumn|null
      */
-    public function getColumnByField($field)
+    public function getColumnByField(string $field): ?AbstractColumn
     {
         foreach ($this->columns as $column) {
             if ($column->getField() == $field) {
@@ -60,7 +58,7 @@ class ColumnBuilder
      * @param string $dql
      * @return AbstractColumn|null
      */
-    public function getColumnByDql($dql)
+    public function getColumnByDql(string $dql): ?AbstractColumn
     {
         foreach ($this->columns as $column) {
             if ($column->getDql() == $dql) {
@@ -79,7 +77,7 @@ class ColumnBuilder
      * @param array $options
      * @return $this
      */
-    public function add($dql, $columnClass, $options = array())
+    public function add(string $dql, string $columnClass, array $options = array()): self
     {
         /** @var AbstractColumn $column */
         $column = new $columnClass($dql, $options);
@@ -96,7 +94,7 @@ class ColumnBuilder
      *
      * @param string $dql
      */
-    public function remove($dql)
+    public function remove(string $dql): void
     {
         foreach ($this->columns as $key => $column) {
             if ($column->getDql() == $dql) {
@@ -109,7 +107,7 @@ class ColumnBuilder
     /**
      * @return array
      */
-    public function buildColumnsArray()
+    public function buildColumnsArray(): array
     {
         $data = array();
         foreach ($this->getColumns() as $column) {
@@ -120,9 +118,10 @@ class ColumnBuilder
     }
 
     /**
+     * @param bool $ignoreAddIf
      * @return AbstractColumn[]
      */
-    public function getColumns($ignoreAddIf = false)
+    public function getColumns(bool $ignoreAddIf = false): array
     {
         if (!$ignoreAddIf) {
             $columns = array();
@@ -138,7 +137,7 @@ class ColumnBuilder
         return $this->columns;
     }
 
-    public function getDefaultButtonOptions()
+    public function getDefaultButtonOptions(): array
     {
         return $this->defaultButtonOptions;
     }

--- a/src/Columns/CountColumn.php
+++ b/src/Columns/CountColumn.php
@@ -9,7 +9,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class CountColumn extends AbstractColumn
 {
 
-    protected function configureInternalOptions(OptionsResolver $resolver)
+    protected function configureInternalOptions(OptionsResolver $resolver): void
     {
         parent::configureInternalOptions($resolver);
 

--- a/src/Columns/DateTimeColumn.php
+++ b/src/Columns/DateTimeColumn.php
@@ -1,15 +1,13 @@
 <?php
 
-
 namespace HelloSebastian\HelloBootstrapTableBundle\Columns;
-
 
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class DateTimeColumn extends AbstractColumn
 {
 
-    protected function configureOutputOptions(OptionsResolver $resolver)
+    protected function configureOutputOptions(OptionsResolver $resolver): void
     {
         parent::configureOutputOptions($resolver);
 

--- a/src/Columns/HiddenColumn.php
+++ b/src/Columns/HiddenColumn.php
@@ -1,14 +1,12 @@
 <?php
 
-
 namespace HelloSebastian\HelloBootstrapTableBundle\Columns;
-
 
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class HiddenColumn extends TextColumn
 {
-    protected function configureOutputOptions(OptionsResolver $resolver)
+    protected function configureOutputOptions(OptionsResolver $resolver): void
     {
         parent::configureOutputOptions($resolver);
 

--- a/src/Columns/LinkColumn.php
+++ b/src/Columns/LinkColumn.php
@@ -8,7 +8,7 @@ class LinkColumn extends AbstractColumn
 {
     use FormatAttributeTrait;
 
-    protected function configureOutputOptions(OptionsResolver $resolver)
+    protected function configureOutputOptions(OptionsResolver $resolver): void
     {
         parent::configureOutputOptions($resolver);
 

--- a/src/Columns/TextColumn.php
+++ b/src/Columns/TextColumn.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace HelloSebastian\HelloBootstrapTableBundle\Columns;
 
 class TextColumn extends AbstractColumn

--- a/src/Data/ActionButton.php
+++ b/src/Data/ActionButton.php
@@ -2,7 +2,6 @@
 
 namespace HelloSebastian\HelloBootstrapTableBundle\Data;
 
-
 use HelloSebastian\HelloBootstrapTableBundle\Columns\AbstractColumn;
 use HelloSebastian\HelloBootstrapTableBundle\Columns\FormatAttributeTrait;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -29,7 +28,7 @@ class ActionButton
      * @param AbstractColumn $column
      * @param array $options
      */
-    public function __construct(AbstractColumn $column, $options)
+    public function __construct(AbstractColumn $column, array $options)
     {
         $this->column = $column;
 
@@ -39,7 +38,7 @@ class ActionButton
         $this->options = $resolver->resolve($options);
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(array(
             'displayName' => null,
@@ -65,7 +64,7 @@ class ActionButton
         $resolver->setAllowedTypes('attr', 'array');
     }
 
-    public function getClassNames()
+    public function getClassNames(): string
     {
         $defaultActionButtonOptions = $this->column->getColumnBuilder()->getDefaultButtonOptions();
         $defaultClassNames = "";
@@ -77,32 +76,32 @@ class ActionButton
         return $classNames . ' ' . $this->options['additionalClassNames'];
     }
 
-    public function getDisplayName()
+    public function getDisplayName(): string
     {
         return $this->options['displayName'];
     }
 
-    public function getRouteName()
+    public function getRouteName(): string
     {
         return $this->options['routeName'];
     }
 
-    public function getRouteParams()
+    public function getRouteParams(): array
     {
         return $this->options['routeParams'];
     }
 
-    public function getOptions()
+    public function getOptions(): array
     {
         return $this->options;
     }
 
-    public function getAddIfCallback()
+    public function getAddIfCallback(): \Closure
     {
         return $this->options['addIf'];
     }
 
-    public function getAttr()
+    public function getAttr(): array
     {
         return $this->options['attr'];
     }

--- a/src/Data/DataBuilder.php
+++ b/src/Data/DataBuilder.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace HelloSebastian\HelloBootstrapTableBundle\Data;
-
 
 use HelloSebastian\HelloBootstrapTableBundle\Columns\AbstractColumn;
 use HelloSebastian\HelloBootstrapTableBundle\Columns\ColumnBuilder;
@@ -27,19 +25,16 @@ class DataBuilder
     /**
      * Loops over all columns and builds data array.
      *
-     * @param $entities
+     * @param array $entities
      * @return array
      */
-    public function buildDataAsArray($entities)
+    public function buildDataAsArray(array $entities): array
     {
         $data = array();
         foreach ($entities as $entity) {
-
             $row = array();
 
-            /** @var AbstractColumn $column */
             foreach ($this->columnBuilder->getColumns() as $column) {
-
                 // if custom data callback is set, execute it.
                 if (!is_null($column->getDataCallback())) {
                     $row[$column->getField()] = $column->getDataCallback()($entity);
@@ -54,5 +49,4 @@ class DataBuilder
 
         return $data;
     }
-
 }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -1,18 +1,14 @@
 <?php
 
-
 namespace HelloSebastian\HelloBootstrapTableBundle\DependencyInjection;
 
-
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
-    /**
-     * @inheritDoc
-     */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('hello_bootstrap_table');
         $rootNode = $treeBuilder->getRootNode();
@@ -29,7 +25,7 @@ class Configuration implements ConfigurationInterface
         return $treeBuilder;
     }
 
-    private function addActionButtonOptions()
+    private function addActionButtonOptions(): NodeDefinition
     {
         $treeBuilder = new TreeBuilder('action_button_options');
         $node = $treeBuilder->getRootNode();
@@ -44,7 +40,7 @@ class Configuration implements ConfigurationInterface
         return $node;
     }
 
-    private function addTableOptions()
+    private function addTableOptions(): NodeDefinition
     {
         $treeBuilder = new TreeBuilder('table_options');
         $node = $treeBuilder->getRootNode();
@@ -69,7 +65,7 @@ class Configuration implements ConfigurationInterface
         return $node;
     }
 
-    private function addTableDatasetOptions()
+    private function addTableDatasetOptions(): NodeDefinition
     {
         $treeBuilder = new TreeBuilder('table_dataset_options');
         $node = $treeBuilder->getRootNode();
@@ -120,7 +116,7 @@ class Configuration implements ConfigurationInterface
         return $node;
     }
 
-    private function addIconsOptions()
+    private function addIconsOptions(): NodeDefinition
     {
         $treeBuilder = new TreeBuilder('icons');
         $node = $treeBuilder->getRootNode();

--- a/src/DependencyInjection/HelloBootstrapTableExtension.php
+++ b/src/DependencyInjection/HelloBootstrapTableExtension.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace HelloSebastian\HelloBootstrapTableBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
@@ -10,10 +9,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class HelloBootstrapTableExtension extends Extension
 {
-    /**
-     * @inheritDoc
-     */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');

--- a/src/Filters/AbstractFilter.php
+++ b/src/Filters/AbstractFilter.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace HelloSebastian\HelloBootstrapTableBundle\Filters;
-
 
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query\Expr\Composite;
@@ -22,7 +20,7 @@ abstract class AbstractFilter
      */
     protected $options;
 
-    public function __construct(AbstractColumn $column, $options)
+    public function __construct(AbstractColumn $column, array $options)
     {
         $this->column = $column;
         $this->options = $options;
@@ -36,7 +34,7 @@ abstract class AbstractFilter
         }
     }
 
-    protected function configureOptions(OptionsResolver $resolver)
+    protected function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(array(
             "advSearchFieldFormatter" => "defaultAdvSearchTextField",
@@ -47,14 +45,14 @@ abstract class AbstractFilter
         $resolver->setAllowedTypes("placeholder", ["string", "null"]);
     }
 
-    public abstract function addExpression(Composite $composite, QueryBuilder $qb, $dql, $search, $key, ClassMetadata $metadata);
+    public abstract function addExpression(Composite $composite, QueryBuilder $qb, string $dql, string $search, int $key, ClassMetadata $metadata): void;
 
-    public function addOrder(QueryBuilder $qb, $dql, $direction, ClassMetadata $metadata)
+    public function addOrder(QueryBuilder $qb, string $dql, string $direction, ClassMetadata $metadata): void
     {
         $qb->addOrderBy($dql, $direction);
     }
 
-    public function getOptions()
+    public function getOptions(): array
     {
         return $this->options;
     }

--- a/src/Filters/BooleanChoiceFilter.php
+++ b/src/Filters/BooleanChoiceFilter.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace HelloSebastian\HelloBootstrapTableBundle\Filters;
-
 
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query\Expr\Composite;
@@ -28,7 +26,7 @@ class BooleanChoiceFilter extends ChoiceFilter
         parent::__construct($column, $options);
     }
 
-    protected function configureOptions(OptionsResolver $resolver)
+    protected function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 
@@ -41,8 +39,7 @@ class BooleanChoiceFilter extends ChoiceFilter
         ));
     }
 
-
-    public function addExpression(Composite $composite, QueryBuilder $qb, $dql, $search, $key, ClassMetadata $metadata)
+    public function addExpression(Composite $composite, QueryBuilder $qb, string $dql, string $search, int $key, ClassMetadata $metadata): void
     {
         if ($search == "null") {
             return;

--- a/src/Filters/ChoiceFilter.php
+++ b/src/Filters/ChoiceFilter.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace HelloSebastian\HelloBootstrapTableBundle\Filters;
-
 
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query\Expr\Composite;
@@ -11,7 +9,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ChoiceFilter extends AbstractFilter
 {
-    protected function configureOptions(OptionsResolver $resolver)
+    protected function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 
@@ -24,7 +22,7 @@ class ChoiceFilter extends AbstractFilter
         $resolver->setAllowedTypes("choices", ["array"]);
     }
 
-    public function addExpression(Composite $composite, QueryBuilder $qb, $dql, $search, $key, ClassMetadata $metadata)
+    public function addExpression(Composite $composite, QueryBuilder $qb, string $dql, string $search, int $key, ClassMetadata $metadata): void
     {
         if ($search == "null") {
             return;

--- a/src/Filters/CountFilter.php
+++ b/src/Filters/CountFilter.php
@@ -16,7 +16,7 @@ class CountFilter extends AbstractFilter
      */
     static $subQueryCounter = 0;
 
-    protected function configureOptions(OptionsResolver $resolver)
+    protected function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 
@@ -29,7 +29,7 @@ class CountFilter extends AbstractFilter
         $resolver->setAllowedTypes("primaryKey", ["string"]);
     }
 
-    public function addOrder(QueryBuilder $qb, $dql, $direction, ClassMetadata $metadata)
+    public function addOrder(QueryBuilder $qb, string $dql, string $direction, ClassMetadata $metadata): void
     {
         $alias = str_replace(".", "_", $dql);
 
@@ -41,7 +41,7 @@ class CountFilter extends AbstractFilter
         $qb->addOrderBy("count_$alias", $direction);
     }
 
-    public function addExpression(Composite $composite, QueryBuilder $qb, $dql, $search, $key, ClassMetadata $metadata)
+    public function addExpression(Composite $composite, QueryBuilder $qb, string $dql, string $search, int $key, ClassMetadata $metadata): void
     {
         if (!is_numeric($search)) {
             return;
@@ -54,7 +54,7 @@ class CountFilter extends AbstractFilter
         $qb->setParameter($key, $search);
     }
 
-    private function createSubQuery(QueryBuilder $qb, ClassMetadata $metadata, $dql)
+    private function createSubQuery(QueryBuilder $qb, ClassMetadata $metadata, string $dql): QueryBuilder
     {
         self::$subQueryCounter++;
 

--- a/src/Filters/TextFilter.php
+++ b/src/Filters/TextFilter.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace HelloSebastian\HelloBootstrapTableBundle\Filters;
-
 
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query\Expr\Composite;
@@ -10,7 +8,7 @@ use Doctrine\ORM\QueryBuilder;
 
 class TextFilter extends AbstractFilter
 {
-    public function addExpression(Composite $composite, QueryBuilder $qb, $dql, $search, $key, ClassMetadata $metadata)
+    public function addExpression(Composite $composite, QueryBuilder $qb, string $dql, string $search, int $key, ClassMetadata $metadata): void
     {
         $composite->add($qb->expr()->like($dql, '?' . $key));
         $qb->setParameter($key, '%' . $search . '%');

--- a/src/HelloBootstrapTableBundle.php
+++ b/src/HelloBootstrapTableBundle.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace HelloSebastian\HelloBootstrapTableBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;

--- a/src/HelloBootstrapTableFactory.php
+++ b/src/HelloBootstrapTableFactory.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace HelloSebastian\HelloBootstrapTableBundle;
 
 
@@ -38,7 +37,7 @@ class HelloBootstrapTableFactory
      */
     private $defaultConfig;
 
-    public function __construct(RouterInterface $router, EntityManagerInterface $em, Environment $twig, Security $security, $defaultConfig = array())
+    public function __construct(RouterInterface $router, EntityManagerInterface $em, Environment $twig, Security $security, array $defaultConfig = array())
     {
         $this->router = $router;
         $this->em = $em;
@@ -54,7 +53,7 @@ class HelloBootstrapTableFactory
      * @param array $options
      * @return HelloBootstrapTable
      */
-    public function create($helloTable, $options = array())
+    public function create(string $helloTable, array $options = array()): HelloBootstrapTable
     {
         if (!\is_string($helloTable)) {
             $type = \gettype($helloTable);

--- a/src/Query/DoctrineQueryBuilder.php
+++ b/src/Query/DoctrineQueryBuilder.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace HelloSebastian\HelloBootstrapTableBundle\Query;
 
 use Doctrine\ORM\EntityManagerInterface;
@@ -65,8 +64,7 @@ class DoctrineQueryBuilder
      */
     private $metadata;
 
-
-    public function __construct(EntityManagerInterface $em, $entityName, ColumnBuilder $columnBuilder)
+    public function __construct(EntityManagerInterface $em, string $entityName, ColumnBuilder $columnBuilder)
     {
         $this->em = $em;
         $this->entityName = $entityName;
@@ -84,9 +82,9 @@ class DoctrineQueryBuilder
      *
      * @param array $requestData
      * @param $enableTotalCountCache $enableCountCache
-     * @return mixed
+     * @return array
      */
-    public function fetchData($requestData, $enableTotalCountCache)
+    public function fetchData(array $requestData, bool $enableTotalCountCache): array
     {
         $this->setupJoinFields();
         $this->setupGlobalSearch($requestData['search']);
@@ -102,7 +100,7 @@ class DoctrineQueryBuilder
         return $this->qb->getQuery()->getResult();
     }
 
-    private function setupSort($sortColumn, $order)
+    private function setupSort($sortColumn, $order): void
     {
         if ($sortColumn) {
             $column = $this->columnBuilder->getColumnByField($sortColumn);
@@ -117,7 +115,7 @@ class DoctrineQueryBuilder
         }
     }
 
-    private function setupFilterSearch($filters)
+    private function setupFilterSearch($filters): void
     {
         // in filter search all searchable columns are connected as an AND expression
         $andExpr = $this->qb->expr()->andX();
@@ -142,7 +140,7 @@ class DoctrineQueryBuilder
         }
     }
 
-    private function setupGlobalSearch($search)
+    private function setupGlobalSearch($search): void
     {
         // in global search all searchable columns are connected as a OR expression
         $orExpr = $this->qb->expr()->orX();
@@ -168,7 +166,7 @@ class DoctrineQueryBuilder
         }
     }
 
-    private function setupJoinFields()
+    private function setupJoinFields(): void
     {
         $joins = array();
 
@@ -201,7 +199,7 @@ class DoctrineQueryBuilder
     /**
      * Executes sub query to count data after filtering was added to query.
      */
-    private function setTotalCountAfterFiltering($enableTotalCountCache)
+    private function setTotalCountAfterFiltering($enableTotalCountCache): void
     {
         try {
             $qb = clone $this->qb;
@@ -227,17 +225,17 @@ class DoctrineQueryBuilder
      *
      * @return int
      */
-    public function getTotalCount()
+    public function getTotalCount(): int
     {
         return $this->totalCountAfterFiltering;
     }
 
-    public function getQueryBuilder()
+    public function getQueryBuilder(): QueryBuilder
     {
         return $this->qb;
     }
 
-    private function getSafeName($name)
+    private function getSafeName($name): string
     {
         try {
             $reservedKeywordsList = $this->em->getConnection()->getDatabasePlatform()->getReservedKeywordsList();
@@ -249,13 +247,13 @@ class DoctrineQueryBuilder
         return $isReservedKeyword ? "_{$name}" : $name;
     }
 
-    private function getIdentifier(ClassMetadata $metadata)
+    private function getIdentifier(ClassMetadata $metadata): ?string
     {
         $identifiers = $metadata->getIdentifierFieldNames();
         return array_shift($identifiers);
     }
 
-    private function getPropertyPath(AbstractColumn $column)
+    private function getPropertyPath(AbstractColumn $column): string
     {
         if ($column->isAssociation()) {
             $path = $column->getPropertyPath();

--- a/src/Response/TableResponse.php
+++ b/src/Response/TableResponse.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace HelloSebastian\HelloBootstrapTableBundle\Response;
-
 
 use HelloSebastian\HelloBootstrapTableBundle\Data\DataBuilder;
 use HelloSebastian\HelloBootstrapTableBundle\HelloBootstrapTable;
@@ -13,8 +11,14 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class TableResponse
 {
-    private $requestData = array();
+    /**
+     * @var array
+     */
+    private $requestData;
 
+    /**
+     * @var string
+     */
     private $defaultRequestUri;
 
     /**
@@ -60,7 +64,7 @@ class TableResponse
      *
      * @param Request $request
      */
-    public function handleRequest(Request $request)
+    public function handleRequest(Request $request): void
     {
         $this->defaultRequestUri = $request->getRequestUri();
 
@@ -84,7 +88,7 @@ class TableResponse
      *
      * @param OptionsResolver $resolver
      */
-    public function configureRequestData(OptionsResolver $resolver)
+    public function configureRequestData(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(array(
             'filter' => array(), //advanced search
@@ -113,7 +117,7 @@ class TableResponse
      * @param boolean $enableTotalCountCache
      * @return array
      */
-    public function getData($enableTotalCountCache)
+    public function getData(bool $enableTotalCountCache): array
     {
         $entities = $this->doctrineQueryBuilder->fetchData($this->requestData, $enableTotalCountCache);
 
@@ -128,7 +132,7 @@ class TableResponse
      *
      * @return bool
      */
-    public function isCallback()
+    public function isCallback(): bool
     {
         return $this->requestData['isCallback'] && $this->requestData['tableName'] == $this->bootstrapTable->getTableName();
     }
@@ -136,9 +140,9 @@ class TableResponse
     /**
      * Sets callback url. Used if callback should handle by other controller.
      *
-     * @param $callbackUrl
+     * @param string $callbackUrl
      */
-    public function setCallbackUrl($callbackUrl)
+    public function setCallbackUrl(string $callbackUrl): void
     {
         $this->callbackUrl = $callbackUrl;
     }
@@ -149,7 +153,7 @@ class TableResponse
      *
      * @return string
      */
-    public function getCallbackUrl()
+    public function getCallbackUrl(): string
     {
         return is_null($this->callbackUrl) ? $this->defaultRequestUri : $this->callbackUrl;
     }

--- a/src/Twig/BootstrapTableTwigExtension.php
+++ b/src/Twig/BootstrapTableTwigExtension.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace HelloSebastian\HelloBootstrapTableBundle\Twig;
-
 
 use Twig\Environment;
 use Twig\Error\LoaderError;
@@ -15,10 +13,7 @@ class BootstrapTableTwigExtension extends AbstractExtension
 {
     const ASSET_VERSION = "5";
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
+    public function getName(): string
     {
         return 'hello_bootstrap_table_twig_extension';
     }
@@ -26,7 +21,7 @@ class BootstrapTableTwigExtension extends AbstractExtension
     /**
      * {@inheritdoc}
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction(
@@ -56,14 +51,14 @@ class BootstrapTableTwigExtension extends AbstractExtension
      * @throws RuntimeError
      * @throws SyntaxError
      */
-    public function helloBootstrapTableRender(Environment $twig, $bootstrapTable)
+    public function helloBootstrapTableRender(Environment $twig, array $bootstrapTable): string
     {
         return $twig->render('@HelloBootstrapTable/table/hello_bootstrap_table.html.twig', array(
             'table' => $bootstrapTable,
         ));
     }
 
-    public function helloBootstrapTableJs(Environment $twig)
+    public function helloBootstrapTableJs(Environment $twig): string
     {
         $assetFunction = $twig->getFunction('asset')->getCallable();
         return sprintf('<script src="%s?v=%s" defer></script>',
@@ -72,7 +67,7 @@ class BootstrapTableTwigExtension extends AbstractExtension
         );
     }
 
-    public function helloBootstrapTableCss(Environment $twig)
+    public function helloBootstrapTableCss(Environment $twig): string
     {
         $assetFunction = $twig->getFunction('asset')->getCallable();
         return sprintf('<link rel="stylesheet" href="%s?v=%s">',


### PR DESCRIPTION
In this update, missing parameter types and return types to all internal and external functions have been added.

Also fixed a bug with the new `enableTotalCountCache` option. (see #34)

Breaking Changes:
Missing types were also added to the methods in the table classes. Among them, the methods `buildColumns`, `getEntityClass`, `configureTableDataset` and `configureTableOptions` are affected.

buildColumns - before:
```php
protected function buildColumns(ColumnBuilder $builder, $options) { }
```

after:
```php
protected function buildColumns(ColumnBuilder $builder, array $options): void { }
```
getEntityClass - before:
```php
protected function getEntityClass() { }
```
after:
```php
protected function getEntityClass(): string { }
```

configureTableDataset - before:
```php
public function configureTableDataset(OptionsResolver $resolver) { }
```

after:
```php
public function configureTableDataset(OptionsResolver $resolver): void { }
```

configureTableOptions - before:
```php
public function configureTableOptions(OptionsResolver $resolver) { }
```

after:
```php
public function configureTableOptions(OptionsResolver $resolver): void { }
```