### PR TITLE
Remove sension framework extra bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
         "ext-json": "*",
         "doctrine/common": "^2.6|^3.0",
         "doctrine/orm": "^2.10",
-        "sensio/framework-extra-bundle": "^5.1|^6.1",
         "symfony/property-access": "^4.4|^5.0|^6.0",
         "symfony/security-bundle": "^4.4|^5.0|^6.0",
         "symfony/twig-bundle": "^4.4|^5.0|^6.0",


### PR DESCRIPTION
It's deprecated by newer versions of symfony, and not really used by bundle